### PR TITLE
bugfix: Acrocentric Chromosome Mismapping

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,3 +3,4 @@ test/chr21_cens.fa.out filter=lfs diff=lfs merge=lfs -text
 test/chr22_cens.fa.out filter=lfs diff=lfs merge=lfs -text
 test/chr21_cens_partials.fa.out filter=lfs diff=lfs merge=lfs -text
 test/chr21_cens_partials.original.pdf filter=lfs diff=lfs merge=lfs -text
+test/chr21_chr13_mismap.fa.out filter=lfs diff=lfs merge=lfs -text

--- a/README.md
+++ b/README.md
@@ -58,7 +58,6 @@ Two metrics are used to determine orientation and mapping.
 ### Algorithm
 1. Every centromeric contig and its reverse orientation is paired with a reference centromeric contig.
     * Repeat types are used to gauge similarity.
-    * Complexity is reduced by merging certain repeat types.
 
 2. Next, the both metrics are calculated for each pair.
     * If both chromosomes in a pair are acrocentric and have similar number of HOR arrays, then only repeats along the q-arm are used.

--- a/cen_stats/acrocentrics.py
+++ b/cen_stats/acrocentrics.py
@@ -49,7 +49,7 @@ def get_q_arm_acro_chr(df_ctg_grp: pl.DataFrame) -> pl.DataFrame:
         return df_ctg_grp.filter(pl.col("start") > alr_repeat["end"][0])
     # | q | alr | p |
     else:
-        return df_ctg_grp.filter(pl.col("end") > alr_repeat["start"][0])
+        return df_ctg_grp.filter(pl.col("end") < alr_repeat["start"][0])
 
 
 def flatten_repeats(df: pl.DataFrame, *, window_size=5) -> pl.DataFrame:

--- a/cen_stats/cli.py
+++ b/cen_stats/cli.py
@@ -22,8 +22,6 @@ from .reference import split_ref_rm_input_by_contig
 from .reader import read_repeatmasker_output
 from .partial_cen import is_partial_centromere
 
-logger.add(sys.stderr, level="INFO")
-
 
 def join_summarize_results(
     df_partial_contig_res: pl.DataFrame,
@@ -104,9 +102,9 @@ def check_cens_status(
     logger.info(f"Read {len(df_ref_grps)} reference dataframes.")
 
     for ctg, df_ctg_grp in df_ctg.group_by(["contig"]):
-        logger.info(f"Evaluating {ctg} with {df_ctg_grp.shape[0]} repeats.")
-
         ctg_name = ctg[0]
+        logger.info(f"Evaluating {ctg_name} with {df_ctg_grp.shape[0]} repeats.")
+
         mtch_chr_name = re.search(RGX_CHR, ctg_name)
         if not mtch_chr_name:
             continue

--- a/cen_stats/reader.py
+++ b/cen_stats/reader.py
@@ -6,52 +6,6 @@ from .constants import RM_COLS
 def read_repeatmasker_output(input_path: str) -> pl.LazyFrame:
     return (
         pl.scan_csv(input_path, separator="\t", has_header=False, new_columns=RM_COLS)
-        .with_columns(
-            pl.col("type")
-            .str.replace_many(
-                [
-                    "/ERVK",
-                    "/ERVL",
-                    "/ERV1",
-                    "/CR1",
-                    "/L1",
-                    "/L2",
-                    "/RTE-X",
-                    "/RTE-BovB",
-                    "/Gypsy",
-                    "-MaLR",
-                    "/Alu",
-                    "/Deu",
-                    "/MIR",
-                    "?",
-                    "/hAT",
-                    "/hAT-Blackjack",
-                    "/hAT-Charlie",
-                    "/MULE-MuDR",
-                    "/PiggyBac",
-                    "/TcMar-Mariner" "/TcMar",
-                    "/TcMar?",
-                    "/hAT-Tip100" "/TcMar-Tigger" "/Dong-R4" "/tRNA",
-                ],
-                "",
-            )
-            .str.replace_many(
-                [
-                    "DNA-Tc2",
-                    "DNA?",
-                    "DNA-Blackjack",
-                    "DNA-Charlie",
-                    "DNA-Tigger",
-                    "DNA-Tip100",
-                ],
-                "DNA",
-            )
-            .str.replace("GSATX", "GSAT")
-            .str.replace("LTR\\S", "LTR")
-            .str.replace("SAR", "HSat1A")
-            .str.replace("HSAT", "HSat1B")
-            .str.replace_many(["HSATII", "(CATTC)n", "(GAATG)n"], "HSat2")
-        )
         .with_columns(dst=pl.col("end") - pl.col("start"))
         .drop("div", "deldiv", "insdiv", "x", "y", "z", "left", "right", "idx")
     )

--- a/test/chr21_chr13_mismap.fa.out
+++ b/test/chr21_chr13_mismap.fa.out
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7b25648384c29f40aa3163d86d8b96f35ca0fedafef90d6b08baf18a30e787ac
+size 1130515

--- a/test/correct_chr21_chr13_mismap_cens.tsv
+++ b/test/correct_chr21_chr13_mismap_cens.tsv
@@ -1,0 +1,3 @@
+correct_chr21_unassigned:2-2293201	correct_chr21_unassigned:2-2293201	fwd	false
+mismapped_chr21_unassigned:2078337-9206433	mismapped_chr13_unassigned:2078337-9206433	rev	false
+chm13_chr21:7700001-11850000	chm13_chr21:7700001-11850000	fwd	false

--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -17,6 +17,10 @@ import subprocess
             "test/chr21_cens_partials.fa.out",
             "test/correct_chr21_partials_cens.tsv",
         ),
+        (
+            "test/chr21_chr13_mismap.fa.out",
+            "test/correct_chr21_chr13_mismap_cens.tsv",
+        ),
     ],
 )
 def test_check_cens_status(input_rm_out: str, expected_rc_list: str):


### PR DESCRIPTION
* Fixed incorrect q-arm detection due to flipped comparison.
* Removed simplification of RepeatMasker output causing mapping errors.
    * Resolves #9 
* Fixed incorrect logging output.
    * Doubled logs.
    * Tuple contig name. 